### PR TITLE
Fix signals and overly verbose logging

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,9 @@
 name: Rust
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
 
 jobs:
   check:
@@ -60,4 +64,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,7 +1931,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wafflemaker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wafflemaker"
 description = "WaffleHack's application deployment service"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Alex Krantz <alex@krantz.dev>"]
 edition = "2018"
 

--- a/src/deployer/docker/events.rs
+++ b/src/deployer/docker/events.rs
@@ -24,7 +24,7 @@ pub async fn watch(mut stop: Receiver<()>) {
         _ = async {
             while let Some(event) = events.next().await {
                 let event = Event::new(event?);
-                if !event.useful() {
+                if matches!(event.action, Action::OutOfScope) {
                     continue;
                 }
 
@@ -139,13 +139,6 @@ impl Action {
             _ => unreachable!(),
         }
     }
-
-    fn useful(&self) -> bool {
-        match self {
-            Self::OutOfScope => false,
-            _ => true,
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -167,9 +160,5 @@ impl Event {
 
     fn name(&self) -> &str {
         self.action.name()
-    }
-
-    fn useful(&self) -> bool {
-        self.action.useful()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn wait_for_exit() -> Result<()> {
     let mut term = signal(SignalKind::terminate())?;
 
     tokio::select! {
-        _ = int.recv() => return Ok(()),
-        _ = term.recv() => return Ok(()),
+        _ = int.recv() => Ok(()),
+        _ = term.recv() => Ok(()),
     }
 }


### PR DESCRIPTION
resolves #1 
resolves #4 

Adds support for gracefully exiting on SIGINT and SIGTERM, and only logs Docker events that are actually used. Gracefully exiting on SIGKILL could not be done as that is the final signal received before a process is killed by the OS.

Also fixes a bug where the service would fail to deploy if the image was not already downloaded as it would try to inspect the image to retrieve the port mapping. The image is now downloaded before it is inspected, as you would expect.