### PR TITLE
Fix wrong certificate resolver

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,9 @@
 name: Rust
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
 
 jobs:
   check:
@@ -60,4 +64,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,7 +1931,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wafflemaker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wafflemaker"
 description = "WaffleHack's application deployment service"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Alex Krantz <alex@krantz.dev>"]
 edition = "2018"
 

--- a/src/deployer/docker/events.rs
+++ b/src/deployer/docker/events.rs
@@ -24,7 +24,7 @@ pub async fn watch(mut stop: Receiver<()>) {
         _ = async {
             while let Some(event) = events.next().await {
                 let event = Event::new(event?);
-                if !event.useful() {
+                if matches!(event.action, Action::OutOfScope) {
                     continue;
                 }
 
@@ -139,13 +139,6 @@ impl Action {
             _ => unreachable!(),
         }
     }
-
-    fn useful(&self) -> bool {
-        match self {
-            Self::OutOfScope => false,
-            _ => true,
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -167,9 +160,5 @@ impl Event {
 
     fn name(&self) -> &str {
         self.action.name()
-    }
-
-    fn useful(&self) -> bool {
-        self.action.useful()
     }
 }

--- a/src/deployer/docker/mod.rs
+++ b/src/deployer/docker/mod.rs
@@ -199,7 +199,7 @@ impl Deployer for Docker {
             );
             labels.insert(
                 format!("traefik.http.routers.{}.tls.certresolver", router_name),
-                "letsencrypt".to_string(),
+                "le".to_string(),
             );
 
             debug!("added routing labels");

--- a/src/deployer/docker/mod.rs
+++ b/src/deployer/docker/mod.rs
@@ -202,7 +202,10 @@ impl Deployer for Docker {
                 "letsencrypt".to_string(),
             );
 
+            debug!("added routing labels");
+
             // Determine the service port
+            info!("attempting to determine service port for load balancing...");
             let image = self
                 .instance
                 .inspect_image(&format!("{}:{}", &options.image, &options.tag))
@@ -215,6 +218,8 @@ impl Deployer for Docker {
                         let mut port = ports.keys().take(1).cloned().next().unwrap();
                         let proto_idx = port.find('/').unwrap();
                         port.truncate(proto_idx);
+
+                        info!("found port {} for service", port);
 
                         labels.insert(
                             format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn wait_for_exit() -> Result<()> {
     let mut term = signal(SignalKind::terminate())?;
 
     tokio::select! {
-        _ = int.recv() => return Ok(()),
-        _ = term.recv() => return Ok(()),
+        _ = int.recv() => Ok(()),
+        _ = term.recv() => Ok(()),
     }
 }


### PR DESCRIPTION
Updates the name of the certificate resolver being used to `le` instead of `letsencrypt` as that is what is currently configured. In the future, this should be made configurable.