### PR TITLE
Add filtering based on branch

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,7 @@ impl Connection {
 
 #[derive(Debug, Deserialize)]
 pub struct Git {
+    pub branch: String,
     pub clone_to: PathBuf,
     pub repository: String,
 }
@@ -228,6 +229,7 @@ mod tests {
         assert_eq!("traefik", network);
         assert_eq!("./state", state.to_str().unwrap());
 
+        assert_eq!("master", &config.git.branch);
         assert_eq!("./configuration", config.git.clone_to.to_str().unwrap());
         assert_eq!("WaffleHacks/waffles", &config.git.repository);
 

--- a/src/webhooks/handlers.rs
+++ b/src/webhooks/handlers.rs
@@ -71,7 +71,7 @@ pub async fn github(raw_body: Bytes, raw_signature: String) -> Result<impl Reply
     };
 
     // Check if the repository is allowed to be pulled
-    if repository.name != cfg.git.repository {
+    if repository.name != cfg.git.repository || !reference.ends_with(&cfg.git.branch) {
         return Err(reject::custom(UndeployableError));
     }
 

--- a/wafflemaker.example.toml
+++ b/wafflemaker.example.toml
@@ -73,6 +73,9 @@
   # The repository to pull configuration from
   repository = "WaffleHacks/waffles"
 
+  # The branch that gets deployed
+  branch = "master"
+
 # Configuration for the management interface
 # NOTE: this allows access to the entire system, it should not be publicly available
 [management]


### PR DESCRIPTION
Adds an additional restriction to what can be deployed by requiring a branch to be specified. Defaults to `master`.