### PR TITLE
Allow service to service networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "arc-swap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+
+[[package]]
 name = "async-recursion"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,7 +166,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.7",
  "url",
  "webpki-roots",
  "winapi",
@@ -259,6 +265,20 @@ dependencies = [
  "indenter",
  "once_cell",
  "owo-colors",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]
@@ -421,6 +441,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -667,7 +693,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.7",
  "tracing",
 ]
 
@@ -1364,6 +1390,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1438,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "redis"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "dtoa",
+ "futures",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "r2d2",
+ "tokio",
+ "tokio-util 0.6.7",
+ "url",
 ]
 
 [[package]]
@@ -1572,6 +1631,15 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -2106,6 +2174,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2424,7 @@ dependencies = [
  "once_cell",
  "rand",
  "rand_chacha",
+ "redis",
  "reqwest",
  "ring",
  "sentry",
@@ -2393,7 +2476,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.7",
  "tower-service",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ bollard = { version = "0.11", features = ["ssl"] }
 git2 = "0.13"
 sled = { version = "0.34", features = ["compression"] }
 
+# DNS
+redis = { version = "0.21.5", default-features = false, features = ["acl", "aio", "connection-manager", "r2d2", "tokio-comp"] }
+
 # Error handling
 anyhow = "1.0"
 thiserror = "1.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     networks:
       default:
         ipv4_address: 172.96.0.5
+      containers:
     depends_on:
       - redis
 
@@ -63,3 +64,5 @@ networks:
     ipam:
       config:
         - subnet: 172.96.0.0/16
+  containers:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,17 @@ services:
       default:
         ipv4_address: 172.96.0.4
 
+  dns:
+    image: wafflehacks/dns:latest
+    environment:
+      - REDIS_URL=172.96.0.4:6379
+      - "REDIS_PREFIX=dns:"
+    networks:
+      default:
+        ipv4_address: 172.96.0.5
+    depends_on:
+      - redis
+
   setup:
     image: wafflehacks/wafflemaker:setup
     build: ./docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ version: "3"
 
 services: 
   postgresql:
-    image: postgres:13-alpine
+    image: postgres:14-alpine
     ports:
-      - 5432:5432
+      - "5432:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -14,9 +14,9 @@ services:
         ipv4_address: 172.96.0.2
   
   vault:
-    image: vault:1.7.2
+    image: vault:1.10.2
     ports:
-      - 8200:8200
+      - "8200:8200"
     environment:
       - VAULT_DEV_ROOT_TOKEN_ID=dev-token
     cap_add: 
@@ -30,9 +30,9 @@ services:
       - postgresql
 
   redis:
-    image: redis:6-alpine
+    image: redis:7-alpine
     ports:
-      - 6379:6379
+      - "6379:6379"
     networks:
       default:
         ipv4_address: 172.96.0.4

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,7 +125,7 @@ impl Connection {
 pub struct Dns {
     pub redis: String,
     pub key_prefix: String,
-    pub zone_suffix: String,
+    pub zone: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -240,7 +240,7 @@ mod tests {
 
         assert_eq!("dns:", &config.dns.key_prefix);
         assert_eq!("redis://127.0.0.1:6379", &config.dns.redis);
-        assert_eq!("wafflemaker.internal", &config.dns.zone_suffix);
+        assert_eq!("wafflemaker.internal", &config.dns.zone);
 
         assert_eq!("master", &config.git.branch);
         assert_eq!("./configuration", config.git.clone_to.to_str().unwrap());

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,7 @@ impl Connection {
 
 #[derive(Debug, Deserialize)]
 pub struct Dns {
+    pub server: String,
     pub redis: String,
     pub key_prefix: String,
     pub zone: String,
@@ -240,6 +241,7 @@ mod tests {
 
         assert_eq!("dns:", &config.dns.key_prefix);
         assert_eq!("redis://127.0.0.1:6379", &config.dns.redis);
+        assert_eq!("127.0.0.1:1053", &config.dns.server);
         assert_eq!("wafflemaker.internal", &config.dns.zone);
 
         assert_eq!("master", &config.git.branch);

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub agent: Agent,
     pub dependencies: Dependencies,
     pub deployment: Deployment,
+    pub dns: Dns,
     pub git: Git,
     pub management: Management,
     pub notifiers: Vec<Notifier>,
@@ -118,6 +119,12 @@ impl Connection {
             Self::Ssl { .. } => "ssl",
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Dns {
+    pub redis: String,
+    pub suffix: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -229,6 +236,9 @@ mod tests {
         assert_eq!(&120, timeout);
         assert_eq!("traefik", network);
         assert_eq!("./state", state.to_str().unwrap());
+
+        assert_eq!("wafflemaker.internal", &config.dns.suffix);
+        assert_eq!("redis://127.0.0.1:6379", &config.dns.redis);
 
         assert_eq!("master", &config.git.branch);
         assert_eq!("./configuration", config.git.clone_to.to_str().unwrap());

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,7 +124,8 @@ impl Connection {
 #[derive(Debug, Deserialize)]
 pub struct Dns {
     pub redis: String,
-    pub suffix: String,
+    pub key_prefix: String,
+    pub zone_suffix: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -237,8 +238,9 @@ mod tests {
         assert_eq!("traefik", network);
         assert_eq!("./state", state.to_str().unwrap());
 
-        assert_eq!("wafflemaker.internal", &config.dns.suffix);
+        assert_eq!("dns:", &config.dns.key_prefix);
         assert_eq!("redis://127.0.0.1:6379", &config.dns.redis);
+        assert_eq!("wafflemaker.internal", &config.dns.zone_suffix);
 
         assert_eq!("master", &config.git.branch);
         assert_eq!("./configuration", config.git.clone_to.to_str().unwrap());

--- a/src/deployer/docker/mod.rs
+++ b/src/deployer/docker/mod.rs
@@ -19,7 +19,6 @@ mod events;
 #[derive(Debug)]
 pub struct Docker {
     instance: Bollard,
-    domain: String,
     state: Db,
     network: Network,
     dns: String,
@@ -29,7 +28,7 @@ impl Docker {
     /// Connect to a new docker instance
     #[instrument(
         name = "docker",
-        skip(connection, endpoint, domain, path),
+        skip(connection, endpoint, path),
         fields(
             connection = connection.kind(),
             endpoint = endpoint.as_ref(),
@@ -41,7 +40,6 @@ impl Docker {
         connection: &Connection,
         endpoint: S,
         timeout: &u64,
-        domain: String,
         dns_server: &str,
         network: S,
         path: P,
@@ -95,7 +93,6 @@ impl Docker {
 
         Ok(Self {
             instance,
-            domain,
             state,
             network,
             dns: dns_server.to_owned(),

--- a/src/deployer/docker/mod.rs
+++ b/src/deployer/docker/mod.rs
@@ -5,7 +5,7 @@ use bollard::{
     container::{Config as CreateContainerConfig, NetworkingConfig, RemoveContainerOptions},
     errors::Error as BollardError,
     image::CreateImageOptions,
-    models::{EndpointSettings, Network},
+    models::{EndpointSettings, HostConfig, Network},
     Docker as Bollard, API_DEFAULT_VERSION,
 };
 use futures::stream::StreamExt;
@@ -22,6 +22,7 @@ pub struct Docker {
     domain: String,
     state: Db,
     network: Network,
+    dns: String,
 }
 
 impl Docker {
@@ -41,6 +42,7 @@ impl Docker {
         endpoint: S,
         timeout: &u64,
         domain: String,
+        dns_server: &str,
         network: S,
         path: P,
         stop: Receiver<()>,
@@ -96,6 +98,7 @@ impl Docker {
             domain,
             state,
             network,
+            dns: dns_server.to_owned(),
         })
     }
 
@@ -251,6 +254,10 @@ impl Deployer for Docker {
             labels: Some(labels),
             networking_config: Some(NetworkingConfig {
                 endpoints_config: self.endpoints_config(),
+            }),
+            host_config: Some(HostConfig {
+                dns: Some(vec![self.dns.clone()]),
+                ..Default::default()
             }),
             ..Default::default()
         };

--- a/src/deployer/docker/mod.rs
+++ b/src/deployer/docker/mod.rs
@@ -96,7 +96,7 @@ impl Docker {
                 h.insert(
                     network_name.clone(),
                     EndpointSettings {
-                        network_id: network.id.clone(),
+                        network_id: network.id,
                         ..Default::default()
                     },
                 );
@@ -200,7 +200,7 @@ impl Deployer for Docker {
 
         if let Some(domain) = &options.domain {
             // Add routing labels
-            let router_name = domain.replace(".", "-");
+            let router_name = domain.replace('.', "-");
             labels.insert(
                 format!("traefik.http.routers.{}.rule", router_name),
                 format!("Host(`{}`)", domain),
@@ -223,7 +223,7 @@ impl Deployer for Docker {
                     if !ports.is_empty() {
                         // The port specification is in the format <port>/<tcp|udp|sctp>, but we
                         // only care about the port itself, the protocol is assumed to be TCP
-                        let mut port = ports.keys().take(1).cloned().next().unwrap();
+                        let mut port = ports.keys().take(1).next().cloned().unwrap();
                         let proto_idx = port.find('/').unwrap();
                         port.truncate(proto_idx);
 

--- a/src/deployer/mod.rs
+++ b/src/deployer/mod.rs
@@ -14,7 +14,7 @@ use error::Result;
 static INSTANCE: OnceCell<Arc<Box<dyn Deployer>>> = OnceCell::new();
 
 /// Create the deployer service and test its connection
-pub async fn initialize(config: &Deployment, stop: Receiver<()>) -> Result<()> {
+pub async fn initialize(config: &Deployment, dns_server: &str, stop: Receiver<()>) -> Result<()> {
     let domain = config.domain.to_owned();
     let deployer: Box<dyn Deployer> = match &config.engine {
         DeploymentEngine::Docker {
@@ -24,7 +24,10 @@ pub async fn initialize(config: &Deployment, stop: Receiver<()>) -> Result<()> {
             network,
             state,
         } => Box::new(
-            Docker::new(connection, endpoint, timeout, domain, network, state, stop).await?,
+            Docker::new(
+                connection, endpoint, timeout, domain, dns_server, network, state, stop,
+            )
+            .await?,
         ),
     };
 

--- a/src/deployer/mod.rs
+++ b/src/deployer/mod.rs
@@ -15,7 +15,6 @@ static INSTANCE: OnceCell<Arc<Box<dyn Deployer>>> = OnceCell::new();
 
 /// Create the deployer service and test its connection
 pub async fn initialize(config: &Deployment, dns_server: &str, stop: Receiver<()>) -> Result<()> {
-    let domain = config.domain.to_owned();
     let deployer: Box<dyn Deployer> = match &config.engine {
         DeploymentEngine::Docker {
             connection,
@@ -25,7 +24,7 @@ pub async fn initialize(config: &Deployment, dns_server: &str, stop: Receiver<()
             state,
         } => Box::new(
             Docker::new(
-                connection, endpoint, timeout, domain, dns_server, network, state, stop,
+                connection, endpoint, timeout, dns_server, network, state, stop,
             )
             .await?,
         ),

--- a/src/deployer/mod.rs
+++ b/src/deployer/mod.rs
@@ -57,6 +57,9 @@ pub trait Deployer: Send + Sync {
     /// Start a service with its ID
     async fn start(&self, id: &str) -> Result<()>;
 
+    /// Get a service's internal IP address
+    async fn ip(&self, id: &str) -> Result<String>;
+
     /// Stop a service with its ID
     async fn stop(&self, id: &str) -> Result<()>;
 

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -1,0 +1,35 @@
+use crate::config::Dns as DnsConfig;
+use once_cell::sync::OnceCell;
+use redis::{Client, RedisResult};
+use std::sync::Arc;
+
+mod service;
+
+pub use service::Dns;
+
+static INSTANCE: OnceCell<Arc<Dns>> = OnceCell::new();
+
+/// Create the DNS management service
+pub async fn initialize(config: &DnsConfig) -> RedisResult<()> {
+    let client = Client::open(config.redis.as_str())?;
+
+    // Test the connection
+    let mut conn = client.get_async_connection().await?;
+    redis::cmd("PING")
+        .query_async::<_, String>(&mut conn)
+        .await?;
+
+    INSTANCE.get_or_init(|| {
+        Arc::from(Dns::new(
+            client,
+            config.key_prefix.clone(),
+            config.zone_suffix.clone(),
+        ))
+    });
+    Ok(())
+}
+
+/// Retrieve an instance of the DNS management service
+pub fn instance() -> Arc<Dns> {
+    INSTANCE.get().unwrap().clone()
+}

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -3,6 +3,7 @@ use once_cell::sync::OnceCell;
 use redis::{Client, RedisResult};
 use std::sync::Arc;
 
+mod records;
 mod service;
 
 pub use service::Dns;
@@ -19,13 +20,9 @@ pub async fn initialize(config: &DnsConfig) -> RedisResult<()> {
         .query_async::<_, String>(&mut conn)
         .await?;
 
-    INSTANCE.get_or_init(|| {
-        Arc::from(Dns::new(
-            client,
-            config.key_prefix.clone(),
-            config.zone_suffix.clone(),
-        ))
-    });
+    let dns = Dns::new(client, &config.key_prefix, &config.zone);
+    INSTANCE.get_or_init(|| Arc::from(dns));
+
     Ok(())
 }
 

--- a/src/dns/records.rs
+++ b/src/dns/records.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+const TTL: usize = 60;
+
+#[derive(Serialize)]
+pub(crate) struct Records<'r> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    a: Option<ARecord<'r>>,
+}
+
+impl<'r> Records<'r> {
+    pub fn a_record(ip: &'r str) -> Self {
+        Self {
+            a: Some(ARecord { ip4: ip, ttl: TTL }),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct ARecord<'r> {
+    ip4: &'r str,
+    ttl: usize,
+}

--- a/src/dns/records.rs
+++ b/src/dns/records.rs
@@ -11,13 +11,13 @@ pub(crate) struct Records<'r> {
 impl<'r> Records<'r> {
     pub fn a_record(ip: &'r str) -> Self {
         Self {
-            a: Some(ARecord { ip4: ip, ttl: TTL }),
+            a: Some(ARecord { ip, ttl: TTL }),
         }
     }
 }
 
 #[derive(Serialize)]
 pub(crate) struct ARecord<'r> {
-    ip4: &'r str,
+    ip: &'r str,
     ttl: usize,
 }

--- a/src/dns/records.rs
+++ b/src/dns/records.rs
@@ -4,14 +4,14 @@ const TTL: usize = 60;
 
 #[derive(Serialize)]
 pub(crate) struct Records<'r> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    a: Option<ARecord<'r>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    a: Vec<ARecord<'r>>,
 }
 
 impl<'r> Records<'r> {
     pub fn a_record(ip: &'r str) -> Self {
         Self {
-            a: Some(ARecord { ip, ttl: TTL }),
+            a: vec![ARecord { ip, ttl: TTL }],
         }
     }
 }

--- a/src/dns/service.rs
+++ b/src/dns/service.rs
@@ -1,18 +1,36 @@
-use redis::Client;
+use super::records::Records;
+use redis::{AsyncCommands, Client, RedisResult};
 
 #[derive(Debug)]
 pub struct Dns {
     client: Client,
-    key_prefix: String,
-    zone_suffix: String,
+    key: String,
 }
 
 impl Dns {
-    pub(crate) fn new(client: Client, key_prefix: String, zone_suffix: String) -> Self {
-        Self {
-            client,
-            key_prefix,
-            zone_suffix,
-        }
+    pub(crate) fn new(client: Client, key_prefix: &str, zone: &str) -> Self {
+        let key = [key_prefix, zone, "."].concat();
+        Self { client, key }
+    }
+
+    /// Register service's DNS record
+    pub async fn register(&self, service: &str, ip: &str) -> RedisResult<()> {
+        // Build the records
+        let records = Records::a_record(ip);
+        let value = serde_json::to_string(&records).unwrap();
+
+        // Insert into the hashmap
+        let mut conn = self.client.get_tokio_connection_manager().await?;
+        conn.hset(&self.key, service, value).await?;
+
+        Ok(())
+    }
+
+    /// Unregister a service's DNS record
+    pub async fn unregister(&self, service: &str) -> RedisResult<()> {
+        let mut conn = self.client.get_tokio_connection_manager().await?;
+        conn.hdel(&self.key, service).await?;
+
+        Ok(())
     }
 }

--- a/src/dns/service.rs
+++ b/src/dns/service.rs
@@ -1,0 +1,18 @@
+use redis::Client;
+
+#[derive(Debug)]
+pub struct Dns {
+    client: Client,
+    key_prefix: String,
+    zone_suffix: String,
+}
+
+impl Dns {
+    pub(crate) fn new(client: Client, key_prefix: String, zone_suffix: String) -> Self {
+        Self {
+            client,
+            key_prefix,
+            zone_suffix,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use args::Args;
 mod args;
 mod config;
 mod deployer;
+mod dns;
 mod git;
 mod http;
 mod management;
@@ -86,6 +87,9 @@ async fn run_server(address: SocketAddr, configuration: &Config) -> Result<()> {
 
     // Connect to Vault (secrets service)
     vault::initialize(&configuration.secrets, stop_tx.clone()).await?;
+
+    // Connect to the DNS management service
+    dns::initialize(&configuration.dns).await?;
 
     // Setup the notifier service
     notifier::initialize()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,12 @@ async fn run_server(address: SocketAddr, configuration: &Config) -> Result<()> {
     let repository_handle = git::initialize(&configuration.git.clone_to);
 
     // Connect to the deployment service
-    deployer::initialize(&configuration.deployment, stop_tx.subscribe()).await?;
+    deployer::initialize(
+        &configuration.deployment,
+        &configuration.dns.server,
+        stop_tx.subscribe(),
+    )
+    .await?;
 
     // Connect to Vault (secrets service)
     vault::initialize(&configuration.secrets, stop_tx.clone()).await?;

--- a/src/processor/jobs/delete_service.rs
+++ b/src/processor/jobs/delete_service.rs
@@ -1,6 +1,6 @@
 use super::Job;
 use crate::{
-    deployer, fail_notify,
+    deployer, dns, fail_notify,
     notifier::{self, Event, State},
     service::registry::REGISTRY,
     vault,
@@ -54,6 +54,8 @@ impl Job for DeleteService {
         fail!(deployer::instance().delete_by_name(&self.name).await);
 
         fail!(vault::instance().revoke_leases(&id).await);
+
+        fail!(dns::instance().unregister(&self.name).await);
 
         if vault::instance()
             .delete_database_role(&self.name)

--- a/src/processor/jobs/delete_service.rs
+++ b/src/processor/jobs/delete_service.rs
@@ -26,7 +26,7 @@ impl Job for DeleteService {
     async fn run(&self) {
         macro_rules! fail {
             ($result:expr) => {
-                fail_notify!(service_delete, &self.name; $result; "an error occurred while deleting service");
+                fail_notify!(service_delete, &self.name; $result; "an error occurred while deleting service")
             };
         }
 

--- a/src/processor/jobs/plan_update.rs
+++ b/src/processor/jobs/plan_update.rs
@@ -46,7 +46,7 @@ impl Job for PlanUpdate {
     async fn run(&self) {
         macro_rules! fail {
             ($result:expr) => {
-                fail_notify!(deployment, &self.after; $result; "an error occurred while planning deployment");
+                fail_notify!(deployment, &self.after; $result; "an error occurred while planning deployment")
             };
         }
 

--- a/src/processor/jobs/plan_update.rs
+++ b/src/processor/jobs/plan_update.rs
@@ -77,7 +77,7 @@ impl Job for PlanUpdate {
                 continue;
             }
 
-            if diff.path.extension().map(OsStr::to_str).flatten() != Some("toml") {
+            if diff.path.extension().and_then(OsStr::to_str) != Some("toml") {
                 info!(path = %diff.path.display(), "skipping non-service file");
                 continue;
             }

--- a/src/processor/jobs/update_service.rs
+++ b/src/processor/jobs/update_service.rs
@@ -31,7 +31,7 @@ impl Job for UpdateService {
     async fn run(&self) {
         macro_rules! fail {
             ($result:expr) => {
-                fail_notify!(service_update, &self.name; $result; "an error occurred while updating service");
+                fail_notify!(service_update, &self.name; $result; "an error occurred while updating service")
             };
         }
 

--- a/src/processor/jobs/update_service.rs
+++ b/src/processor/jobs/update_service.rs
@@ -50,7 +50,7 @@ impl Job for UpdateService {
             .image(&service.docker.image, &service.docker.tag);
 
         if service.web.enabled {
-            let subdomain = self.name.replace("-", ".");
+            let subdomain = self.name.replace('-', ".");
             let base = match &service.web.base {
                 Some(base) => base,
                 None => &config.deployment.domain,

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -34,7 +34,7 @@ async fn load_dir(reg: &mut HashMap<String, Service>, path: &Path) -> Result<()>
             continue;
         }
 
-        if entry.path().extension().map(OsStr::to_str).flatten() != Some("toml") {
+        if entry.path().extension().and_then(OsStr::to_str) != Some("toml") {
             continue;
         }
 

--- a/wafflemaker.example.toml
+++ b/wafflemaker.example.toml
@@ -73,9 +73,12 @@
   # The Redis store to put DNS records in for consumption by CoreDNS
   redis = "redis://127.0.0.1:6379"
 
+  # The prefix to give to all DNS keys in Redis
+  key_prefix = "dns:"
+
   # The internal DNS suffix for the services
   # The generated DNS addresses will be in the form <service>.<suffix>
-  suffix = "wafflemaker.internal"
+  zone_suffix = "wafflemaker.internal"
 
 # Configuration for the services repository
 [git]

--- a/wafflemaker.example.toml
+++ b/wafflemaker.example.toml
@@ -70,6 +70,9 @@
 
 # Configuration for internal DNS networking
 [dns]
+  # The DNS server the services should use
+  server = "127.0.0.1:1053"
+
   # The Redis store to put DNS records in for consumption by CoreDNS
   redis = "redis://127.0.0.1:6379"
 

--- a/wafflemaker.example.toml
+++ b/wafflemaker.example.toml
@@ -68,6 +68,15 @@
   # The certificate key to use
   #key = "./key.pem"
 
+# Configuration for internal DNS networking
+[dns]
+  # The Redis store to put DNS records in for consumption by CoreDNS
+  redis = "redis://127.0.0.1:6379"
+
+  # The internal DNS suffix for the services
+  # The generated DNS addresses will be in the form <service>.<suffix>
+  suffix = "wafflemaker.internal"
+
 # Configuration for the services repository
 [git]
   # Where to clone the configuration repository to

--- a/wafflemaker.example.toml
+++ b/wafflemaker.example.toml
@@ -76,9 +76,8 @@
   # The prefix to give to all DNS keys in Redis
   key_prefix = "dns:"
 
-  # The internal DNS suffix for the services
-  # The generated DNS addresses will be in the form <service>.<suffix>
-  zone_suffix = "wafflemaker.internal"
+  # The internal DNS zone for the services
+  zone = "wafflemaker.internal"
 
 # Configuration for the services repository
 [git]


### PR DESCRIPTION
Add support for service-to-service networking using [CoreDNS](https://coredns.io) records configured with the [coredns-redis](https://github.com/WaffleHacks/coredns-redis) plugin.