### PR TITLE
Add path prefix routing

### DIFF
--- a/docker/scripts/vault.py
+++ b/docker/scripts/vault.py
@@ -37,10 +37,14 @@ def send_request(
 print("Ensuring Vault is initialized...")
 success = False
 for attempt in range(10):
-    response = requests.get(f"{ADDRESS}/v1/sys/init")
-    if response.json().get("initialized"):
-        success = True
-        break
+    try:
+        response = requests.get(f"{ADDRESS}/v1/sys/init")
+        if response.json().get("initialized"):
+            success = True
+            break
+    except ConnectionError:
+        print("\tconnection timeout, retrying in 1s")
+        pass
 
     sleep(1)
 

--- a/example-service.toml
+++ b/example-service.toml
@@ -19,6 +19,10 @@
   # Whether to enable web access (default: true)
   enabled = true
 
+  # An optional path prefix to run the application under
+  # When not provided, the service will run on the base domain
+  path = "/testing"
+
   # The domain where the application can be accessed
   # Defaults to the filename combined with the `deployment.domain` key in the configuration
   domain = "testing.wafflehacks.tech"

--- a/src/deployer/docker/mod.rs
+++ b/src/deployer/docker/mod.rs
@@ -159,8 +159,8 @@ impl Deployer for Docker {
         skip(self, options),
         fields(
             name = %options.name,
-            web = %options.domain.is_some(),
-            domain = ?options.domain,
+            web = %options.routing.is_some(),
+            routing = ?options.routing,
             image = %options.image),
         )
     ]
@@ -198,12 +198,12 @@ impl Deployer for Docker {
             }
         }
 
-        if let Some(domain) = &options.domain {
+        if let Some(routing) = &options.routing {
             // Add routing labels
-            let router_name = domain.replace('.', "-");
+            let router_name = routing.domain.replace('.', "-");
             labels.insert(
                 format!("traefik.http.routers.{}.rule", router_name),
-                format!("Host(`{}`)", domain),
+                format!("Host(`{}`)", routing.domain),
             );
             labels.insert(
                 format!("traefik.http.routers.{}.tls.certresolver", router_name),
@@ -244,7 +244,7 @@ impl Deployer for Docker {
         // Enable traefik if a domain is added
         labels.insert(
             "traefik.enable".to_string(),
-            options.domain.is_some().to_string(),
+            options.routing.is_some().to_string(),
         );
 
         let config = CreateContainerConfig {

--- a/src/deployer/mod.rs
+++ b/src/deployer/mod.rs
@@ -77,6 +77,7 @@ pub trait Deployer: Send + Sync {
 pub struct CreateOpts {
     name: String,
     domain: Option<String>,
+    path: Option<String>,
     environment: HashMap<String, String>,
     image: String,
     tag: String,
@@ -94,6 +95,7 @@ impl CreateOpts {
 pub struct CreateOptsBuilder {
     name: String,
     domain: Option<String>,
+    path: Option<String>,
     environment: HashMap<String, String>,
     image: String,
     tag: String,
@@ -117,6 +119,12 @@ impl CreateOptsBuilder {
         self
     }
 
+    /// Set the path prefix
+    pub fn path<S: Into<String>>(mut self, path: S) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
     /// Set the image to deploy
     pub fn image<S: Into<String>>(mut self, image: S, tag: S) -> Self {
         self.image = image.into();
@@ -136,6 +144,7 @@ impl CreateOptsBuilder {
         CreateOpts {
             name: self.name,
             domain: self.domain,
+            path: self.path,
             environment: self.environment,
             image: self.image,
             tag: self.tag,
@@ -161,6 +170,7 @@ mod tests {
         let opts = CreateOpts {
             name: "hello-world".into(),
             domain: Some("hello.world".into()),
+            path: Some("/testing".into()),
             environment: map,
             image: "wafflehacks/testing".into(),
             tag: "latest".into(),
@@ -169,6 +179,7 @@ mod tests {
             .name("hello-world")
             .image("wafflehacks/testing", "latest")
             .domain("hello.world")
+            .path("/testing")
             .environment("another", "VaLuE")
             .environment(
                 "database_url",

--- a/src/processor/jobs/update_service.rs
+++ b/src/processor/jobs/update_service.rs
@@ -58,12 +58,8 @@ impl Job for UpdateService {
                     &config.deployment.domain
                 ),
             };
-            let path_prefix = match &service.web.path {
-                Some(p) => p.as_str(),
-                None => "",
-            };
 
-            options = options.domain(domain).path(path_prefix);
+            options = options.routing(domain, service.web.path.as_deref());
         }
 
         for (k, v) in service.environment.iter() {

--- a/src/processor/jobs/update_service.rs
+++ b/src/processor/jobs/update_service.rs
@@ -58,8 +58,12 @@ impl Job for UpdateService {
                     &config.deployment.domain
                 ),
             };
+            let path_prefix = match &service.web.path {
+                Some(p) => p.as_str(),
+                None => "",
+            };
 
-            options = options.domain(domain);
+            options = options.domain(domain).path(path_prefix);
         }
 
         for (k, v) in service.environment.iter() {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -121,6 +121,9 @@ pub struct Web {
     #[serde(default)]
     #[serde_as(as = "NoneAsEmptyString")]
     pub domain: Option<String>,
+    #[serde(default)]
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub path: Option<String>,
 }
 
 impl Default for Web {
@@ -128,6 +131,7 @@ impl Default for Web {
         Web {
             enabled: true,
             domain: None,
+            path: None,
         }
     }
 }
@@ -160,6 +164,7 @@ mod tests {
         assert_eq!(service.secrets.len(), 6);
         assert_eq!(service.web.enabled, true);
         assert_eq!(service.web.domain, Some("testing.wafflehacks.tech".into()));
+        assert_eq!(service.web.path, Some("/testing".into()));
     }
 
     #[tokio::test]
@@ -178,5 +183,6 @@ mod tests {
         assert_eq!(service.secrets.len(), 0);
         assert_eq!(service.web.enabled, true);
         assert_eq!(service.web.domain, None);
+        assert_eq!(service.web.path, None);
     }
 }


### PR DESCRIPTION
This adds support for path prefix routing so multiple services can exist on the same domain. Path prefix routing is required for the [application portal](https://github.com/WaffleHacks/application-portal) as all API components exist on the same domain.