### PR TITLE
Better nested services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,15 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
@@ -1896,6 +1905,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shrinkwraprs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
+dependencies = [
+ "bitflags",
+ "itertools 0.8.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2463,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "shrinkwraprs",
  "sled",
  "structopt",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ itertools = '0.10'
 once_cell = "1.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.9"
+shrinkwraprs = "0.3"
 tokio = { version = "1.6", features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "time"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
 

--- a/docker/scripts/wafflemaker.hcl
+++ b/docker/scripts/wafflemaker.hcl
@@ -1,5 +1,5 @@
 # Allow reading and writing to services configuration KV
-path "services/data/+" {
+path "services/data/*" {
   capabilities = ["create", "update", "read"]
 }
 

--- a/src/management/services.rs
+++ b/src/management/services.rs
@@ -96,13 +96,13 @@ async fn redeploy(service: String) -> Result<impl Reply, Rejection> {
     let reg = REGISTRY.read().await;
     let config = reg.get(&service).ok_or_else(warp::reject::not_found)?;
 
-    jobs::dispatch(UpdateService::new(config.clone(), service));
+    jobs::dispatch(UpdateService::new(config.clone(), service.into()));
 
     Ok(StatusCode::NO_CONTENT)
 }
 
 /// Delete a service
 async fn delete(service: String) -> Result<impl Reply, Rejection> {
-    jobs::dispatch(DeleteService::new(service));
+    jobs::dispatch(DeleteService::new(service.into()));
     Ok(StatusCode::NO_CONTENT)
 }

--- a/src/management/services.rs
+++ b/src/management/services.rs
@@ -5,7 +5,7 @@ use crate::{
     registry::REGISTRY,
 };
 use serde::Serialize;
-use warp::{http::StatusCode, Filter, Rejection, Reply};
+use warp::{http::StatusCode, path::Tail, Filter, Rejection, Reply};
 
 /// Build the routes for services
 pub fn routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
@@ -15,18 +15,15 @@ pub fn routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clo
         .with(named_trace("list"));
 
     let get = warp::get()
-        .and(warp::path::param())
-        .and(warp::path::end())
+        .and(warp::path::tail())
         .and_then(get)
         .with(named_trace("get"));
     let redeploy = warp::put()
-        .and(warp::path::param())
-        .and(warp::path::end())
+        .and(warp::path::tail())
         .and_then(redeploy)
         .with(named_trace("redeploy"));
     let delete = warp::delete()
-        .and(warp::path::param())
-        .and(warp::path::end())
+        .and(warp::path::tail())
         .and_then(delete)
         .with(named_trace("delete"));
 
@@ -57,11 +54,13 @@ struct DependenciesResponse {
 }
 
 /// Get the configuration for a service
-async fn get(service: String) -> Result<impl Reply, Rejection> {
-    let reg = REGISTRY.read().await;
-    let cfg = reg.get(&service).ok_or_else(warp::reject::not_found)?;
+async fn get(service: Tail) -> Result<impl Reply, Rejection> {
+    let service = service.as_str();
 
-    let deployment_id = deployer::instance().service_id(&service).await?;
+    let reg = REGISTRY.read().await;
+    let cfg = reg.get(service).ok_or_else(warp::reject::not_found)?;
+
+    let deployment_id = deployer::instance().service_id(service).await?;
 
     let dependencies = DependenciesResponse {
         postgres: cfg.dependencies.postgres("").is_some(),
@@ -92,9 +91,11 @@ async fn get(service: String) -> Result<impl Reply, Rejection> {
 }
 
 /// Re-deploy a service
-async fn redeploy(service: String) -> Result<impl Reply, Rejection> {
+async fn redeploy(service: Tail) -> Result<impl Reply, Rejection> {
+    let service = service.as_str();
+
     let reg = REGISTRY.read().await;
-    let config = reg.get(&service).ok_or_else(warp::reject::not_found)?;
+    let config = reg.get(service).ok_or_else(warp::reject::not_found)?;
 
     jobs::dispatch(UpdateService::new(config.clone(), service.into()));
 
@@ -102,7 +103,7 @@ async fn redeploy(service: String) -> Result<impl Reply, Rejection> {
 }
 
 /// Delete a service
-async fn delete(service: String) -> Result<impl Reply, Rejection> {
-    jobs::dispatch(DeleteService::new(service.into()));
+async fn delete(service: Tail) -> Result<impl Reply, Rejection> {
+    jobs::dispatch(DeleteService::new(service.as_str().into()));
     Ok(StatusCode::NO_CONTENT)
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -2,14 +2,17 @@ use crate::config;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr, NoneAsEmptyString};
+use std::fmt::Debug;
 use std::{collections::HashMap, ffi::OsStr, path::Path};
 use tokio::fs;
 
 mod dependency;
+mod name;
 pub mod registry;
 mod secret;
 
 use dependency::*;
+pub use name::ServiceName;
 pub use secret::{Format, Part as AWSPart, Secret};
 
 /// The configuration for a service
@@ -34,15 +37,18 @@ impl Service {
     }
 
     /// Generate the name of a service from its file path
-    pub fn name(path: &Path) -> String {
-        path.strip_prefix(&config::instance().git.clone_to)
+    pub fn name(path: &Path) -> ServiceName {
+        let name = path
+            .strip_prefix(&config::instance().git.clone_to)
             .unwrap_or(path)
             .with_extension("")
             .iter()
             .map(OsStr::to_str)
             .map(Option::unwrap)
             .collect::<Vec<_>>()
-            .join("/")
+            .join("/");
+
+        ServiceName::new(name)
     }
 }
 

--- a/src/service/name.rs
+++ b/src/service/name.rs
@@ -1,0 +1,65 @@
+use itertools::Itertools;
+use shrinkwraprs::Shrinkwrap;
+use std::fmt::{Debug, Display, Formatter};
+
+/// The different ways of referring to a service. Can be used as a standard string via [shrinkwraprs::Shrinkwrap]
+#[derive(Shrinkwrap)]
+pub struct ServiceName {
+    /// The proper name of the service by which most things should refer to it
+    #[shrinkwrap(main_field)]
+    pub proper: String,
+    /// The domain/subdomain name of the service
+    pub domain: String,
+    /// A sanitized version of the name containing only a-z, A-Z, 0-9, -, .
+    pub sanitized: String,
+}
+
+impl ServiceName {
+    pub(super) fn new<S: Into<String>>(name: S) -> ServiceName {
+        let proper = name.into();
+        let domain = proper.split('/').rev().join(".");
+        let sanitized = proper.replace('/', ".");
+
+        ServiceName {
+            proper,
+            domain,
+            sanitized,
+        }
+    }
+}
+
+impl AsRef<str> for ServiceName {
+    fn as_ref(&self) -> &str {
+        self.proper.as_ref()
+    }
+}
+
+impl Debug for ServiceName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.proper, f)
+    }
+}
+
+impl Display for ServiceName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.proper, f)
+    }
+}
+
+impl From<&str> for ServiceName {
+    fn from(name: &str) -> Self {
+        ServiceName::new(name)
+    }
+}
+
+impl From<String> for ServiceName {
+    fn from(name: String) -> Self {
+        ServiceName::new(name)
+    }
+}
+
+impl From<&String> for ServiceName {
+    fn from(name: &String) -> Self {
+        ServiceName::new(name)
+    }
+}

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -42,7 +42,7 @@ async fn load_dir(reg: &mut HashMap<String, Service>, path: &Path) -> Result<()>
         let service = Service::parse(&entry.path()).await?;
 
         debug!("loaded service {}", &name);
-        reg.insert(name, service);
+        reg.insert(name.proper, service);
     }
 
     Ok(())

--- a/src/vault/models.rs
+++ b/src/vault/models.rs
@@ -60,7 +60,7 @@ impl<'paths> Capabilities<'paths> {
         m.insert("aws/creds/+", set![Read]);
         m.insert("database/creds/+", set![Read]);
         m.insert("database/roles/+", set![List, Create, Delete]);
-        m.insert("services/data/+", set![Create, Read, Update]);
+        m.insert("services/data/*", set![Create, Read, Update]);
         m
     }
 

--- a/src/vault/renewal.rs
+++ b/src/vault/renewal.rs
@@ -70,7 +70,7 @@ pub async fn leases(interval: Duration, max_percent: f64, mut stop: Receiver<()>
                                 Err(e) => {
                                     let reg = REGISTRY.read().await;
                                     if let Some(config) = reg.get(service) {
-                                        jobs::dispatch(UpdateService::new(config.clone(), service.to_owned()));
+                                        jobs::dispatch(UpdateService::new(config.clone(), service.into()));
                                     }
 
                                     warn!(parent: &span, id = %lease.id, error = %e, "failed to renew lease");

--- a/src/webhooks/handlers.rs
+++ b/src/webhooks/handlers.rs
@@ -46,7 +46,7 @@ pub async fn docker(body: Docker, authorization: String) -> Result<impl Reply, R
         let mut updated = service.clone();
         updated.docker.tag = body.push_data.tag.clone();
 
-        jobs::dispatch(UpdateService::new(updated, name.clone()));
+        jobs::dispatch(UpdateService::new(updated, name.into()));
         info!("updating service \"{}\"", name);
     }
 

--- a/wafflemaker.example.toml
+++ b/wafflemaker.example.toml
@@ -163,7 +163,7 @@
   lease_percent = 0.75
 
   # A Vault token that has the following permissions:
-  #   - create, read, update on services/data/+
+  #   - create, read, update on services/data/*
   #   - list, create, delete on database/roles/+ for a database named "postgresql"
   #   - read on database/creds/+
   #   - read on aws/creds/+


### PR DESCRIPTION
This makes using nested services work as you would intuitively expect. Namely:
- secrets are read from the same path as on the filesystem (i.e. the filesystem path `abc/def/ghi` would be read from `abc/def/ghi` in Vault)
- internal and external domains now use the reversed path as the subdomain (i.e. the path `abc/def/ghi` would correspond to `ghi.def.abc.<base domain>`)

The required permissions were also increased on the services KV engine from being able to read 1 level deep to an arbitrary number of levels deep.

Support was also added to the management API to support nested services. Before, the API would respond with a 404 as it only supported a single parameter for the service name. Now it supports an arbitrary number of parameters.